### PR TITLE
CHG: chg/add quantiles methods for wfpt, and fix _plot_posterior_quantil...

### DIFF
--- a/hddm/likelihoods.py
+++ b/hddm/likelihoods.py
@@ -202,9 +202,11 @@ def add_quantiles_functions_to_pymc_class(pymc_class):
 
     def theoretical_quantiles(self, quantiles=(.1, .3, .5, .7, .9)):
         """
-        return the quantiles of the Stochastic's value
+        return the theoretical quantiles based on Stochastic's parents
         Output:
-            lower_boundary_quantiles, upper_boundary_quantiles
+            q_lower - lower boundary quantiles
+            q_upper - upper_boundary_quantiles
+            p_upper - probability of hitting the upper boundary
         """
 
         quantiles = np.asarray(quantiles)

--- a/hddm/utils.py
+++ b/hddm/utils.py
@@ -708,6 +708,13 @@ def plot_posterior_quantiles(model, **kwargs):
                                              **kwargs)
 
 
+def create_test_model(samples=5000, burn=1000, subjs=1, size=100):
+    data, params = hddm.generate.gen_rand_data(subjs=subjs, size=size)
+    m = hddm.HDDM(data)
+    m.sample(samples, burn=burn)
+
+    return m
+
 def data_quantiles(data, quantiles = (0.1, 0.3, 0.5, 0.7, 0.9)):
     if isinstance(data, pd.DataFrame):
         data = flip_errors(data).rt


### PR DESCRIPTION
remove Wfpt.quantiles
added Wfpt.empirical_quantiles - compute the quantiles over the stochastic's value
added Wfpt.theo_quantiles - compute the theoretical quantiles based on  stochastic's parents

fix: _plot_posterior_quantiles used the theoretical quantiles, but it should have been generating Wfpt values, based on the trace of the parents and then compute the quantiles of the new generated values.
