### PR TITLE
Replacing .ix with .iloc/.loc

### DIFF
--- a/hddm/generate.py
+++ b/hddm/generate.py
@@ -680,11 +680,11 @@ def add_outliers(data, n_fast, n_slow, seed=None):
     outliers = data.iloc[idx, :].copy()
 
     # fast outliers
-    outliers.loc[:n_fast, 'rt'] = np.random.rand(
+    outliers.loc[:, 'rt'].iloc[:n_fast] = np.random.rand(
         n_fast) * (min(abs(data['rt'])) - 0.1001) + 0.1001
 
     # slow outliers
-    outliers.loc[n_fast:, 'rt'] = np.random.rand(
+    outliers.loc[:, 'rt'].iloc[n_fast:] = np.random.rand(
         n_slow) * 2 + max(abs(data['rt']))
     outliers['response'] = np.random.randint(0, 2, n_outliers)
 

--- a/hddm/generate.py
+++ b/hddm/generate.py
@@ -677,7 +677,7 @@ def add_outliers(data, n_fast, n_slow, seed=None):
 
     # init outliers DataFrame
     idx = np.random.permutation(len(data))[:n_outliers]
-    outliers = data.ix[idx].copy()
+    outliers = data.iloc[idx, :].copy()
 
     # fast outliers
     outliers.loc[:n_fast, 'rt'] = np.random.rand(

--- a/hddm/models/base.py
+++ b/hddm/models/base.py
@@ -106,7 +106,7 @@ class AccumulatorModel(kabuki.Hierarchical):
             #set average quantiles  to have the same statitics
             obs_knode = [x for x in self.knodes if x.name == 'wfpt'][0]
             node_name = obs_knode.create_node_name(tag) #get node name
-            average_node = average_model.nodes_db.ix[node_name]['node'] #get the average node
+            average_node = average_model.nodes_db.loc[node_name]['node'] #get the average node
             average_node.set_quantiles_stats(quantiles, n_samples, emp_rt, freq_obs, p_upper) #set the quantiles
 
         return average_model
@@ -163,7 +163,7 @@ class AccumulatorModel(kabuki.Hierarchical):
                              method=method, quantiles=quantiles, n_runs=n_runs):
 
             #resample data
-            new_data = data.ix[np.random.randint(0, len(data), len(data))]
+            new_data = data.iloc[np.random.randint(0, len(data), len(data))]
             new_data = new_data.set_index(pd.Index(list(range(len(data)))))
             h = accumulator_class(new_data, **class_kwargs)
 
@@ -175,7 +175,7 @@ class AccumulatorModel(kabuki.Hierarchical):
         #bootstrap iterations
         for i_strap in range(n_bootstraps):
             if view is None:
-                res.ix[i_strap] = single_bootstrap(self.data)
+                res.iloc[i_strap] = single_bootstrap(self.data)
             else:
                 # append to job queue
                 runs_list[i_strap] = view.apply_async(single_bootstrap, self.data)
@@ -184,7 +184,7 @@ class AccumulatorModel(kabuki.Hierarchical):
         if view is not None:
             view.wait(runs_list)
             for i_strap in range(n_bootstraps):
-                res.ix[i_strap] = runs_list[i_strap].get()
+                res.iloc[i_strap] = runs_list[i_strap].get()
 
         #get statistics
         stats = res.describe()

--- a/hddm/models/hddm_regression.py
+++ b/hddm/models/hddm_regression.py
@@ -47,7 +47,7 @@ def generate_wfpt_reg_stochastic_class(wiener_params=None, sampling_method='cdf'
             samples = hddm.generate.gen_rts(method=sampling_method,
                                             size=1, dt=sampling_dt, **param_dict)
 
-            sampled_rts.loc[i]['rt'] = hddm.utils.flip_errors(samples).rt
+            sampled_rts.loc[i, 'rt'] = hddm.utils.flip_errors(samples).rt
 
         return sampled_rts
 

--- a/hddm/models/hddm_regression.py
+++ b/hddm/models/hddm_regression.py
@@ -26,7 +26,7 @@ def generate_wfpt_reg_stochastic_class(wiener_params=None, sampling_method='cdf'
         """Log-likelihood for the full DDM using the interpolation method"""
         params = {'v': v, 'sv': sv, 'a': a, 'z': z, 'sz': sz, 't': t, 'st': st}
         for reg_outcome in reg_outcomes:
-            params[reg_outcome] = params[reg_outcome].ix[value['rt'].index].values
+            params[reg_outcome] = params[reg_outcome].loc[value['rt'].index].values
         return hddm.wfpt.wiener_like_multi(value['rt'].values,
                                            params['v'], params['sv'], params['a'], params['z'],
                                            params['sz'], params['t'], params['st'], 1e-4,
@@ -42,12 +42,12 @@ def generate_wfpt_reg_stochastic_class(wiener_params=None, sampling_method='cdf'
         for i in self.value.index:
             #get current params
             for p in self.parents['reg_outcomes']:
-                param_dict[p] = np.asscalar(self.parents.value[p].ix[i])
+                param_dict[p] = np.asscalar(self.parents.value[p].loc[i])
             #sample
             samples = hddm.generate.gen_rts(method=sampling_method,
                                             size=1, dt=sampling_dt, **param_dict)
 
-            sampled_rts.ix[i]['rt'] = hddm.utils.flip_errors(samples).rt
+            sampled_rts.loc[i]['rt'] = hddm.utils.flip_errors(samples).rt
 
         return sampled_rts
 

--- a/hddm/tests/benchmark.py
+++ b/hddm/tests/benchmark.py
@@ -86,7 +86,7 @@ def check_outlier_model(seed=None, p_outlier=0.05):
     hm = hddm.HDDMTruncated(data,include='p_outlier')
     hm.map()
     df = pd.DataFrame([best_estimate, hm.values], index=index, dtype=np.float)
-    df.loc['best_estimate']['p_outlier'] = 0
+    df.loc['best_estimate', 'p_outlier'] = 0
     print("MAP with random p_outlier (Estimated from the data)")
     print(df.dropna(1))
 

--- a/hddm/tests/benchmark.py
+++ b/hddm/tests/benchmark.py
@@ -86,7 +86,7 @@ def check_outlier_model(seed=None, p_outlier=0.05):
     hm = hddm.HDDMTruncated(data,include='p_outlier')
     hm.map()
     df = pd.DataFrame([best_estimate, hm.values], index=index, dtype=np.float)
-    df.ix['best_estimate']['p_outlier'] = 0
+    df.loc['best_estimate']['p_outlier'] = 0
     print("MAP with random p_outlier (Estimated from the data)")
     print(df.dropna(1))
 

--- a/hddm/tests/test_models.py
+++ b/hddm/tests/test_models.py
@@ -122,37 +122,37 @@ class TestSingleBreakdown(unittest.TestCase):
         data, params_subj = hddm.generate.gen_rand_data(subjs=4, params=params, size=10)
         m = hddm.HDDMTruncated(data)
         m.sample(self.iter, burn=self.burn)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['mu'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['tau'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['tau'].parents['x'], pm.Uniform)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'], pm.TruncatedNormal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['mu'], pm.Uniform)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['tau'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['tau'].parents['x'], pm.Uniform)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'], pm.TruncatedNormal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['tau'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['tau'].parents['x'], pm.Uniform)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['mu'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['tau'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['tau'].parents['x'], pm.Uniform)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'], pm.TruncatedNormal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['mu'], pm.Uniform)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['tau'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['tau'].parents['x'], pm.Uniform)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'], pm.TruncatedNormal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['tau'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['tau'].parents['x'], pm.Uniform)
 
     def test_HDDM_distributions(self):
         params = hddm.generate.gen_rand_params()
         data, params_subj = hddm.generate.gen_rand_data(subjs=4, params=params, size=10)
         m = hddm.HDDM(data)
         m.sample(self.iter, burn=self.burn)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['mu'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['tau'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['tau'].parents['x'], pm.HalfNormal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['alpha'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['alpha'].parents['x'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['beta'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['beta'].parents['y'], pm.HalfNormal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['alpha'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['alpha'].parents['x'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['beta'], pm.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt.0']['node'].parents['t'].parents['beta'].parents['y'], pm.HalfNormal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['mu'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['tau'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['tau'].parents['x'], pm.HalfNormal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['alpha'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['alpha'].parents['x'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['beta'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['beta'].parents['y'], pm.HalfNormal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['alpha'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['alpha'].parents['x'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['beta'], pm.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt.0']['node'].parents['t'].parents['beta'].parents['y'], pm.HalfNormal)
 
 
     def test_HDDMStimCoding(self):
@@ -160,26 +160,26 @@ class TestSingleBreakdown(unittest.TestCase):
         data, params_subj = hddm.generate.gen_rand_data(params=params_full, size=10)
         m = hddm.HDDMStimCoding(data, stim_col='condition', split_param='v')
         m.sample(self.iter, burn=self.burn)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c1)']['node'].parents['v'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'].parents['self'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c1)']['node'].parents['v'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'].parents['self'], pm.Normal)
 
         m = hddm.HDDMStimCoding(data, stim_col='condition', split_param='z')
         m.sample(self.iter, burn=self.burn)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c1)']['node'].parents['z'], pm.CommonDeterministics.InvLogit)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['z'], pm.PyMCObjects.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['z'].parents['a'], int)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['z'].parents['b'], pm.CommonDeterministics.InvLogit)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c1)']['node'].parents['z'], pm.CommonDeterministics.InvLogit)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['z'], pm.PyMCObjects.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['z'].parents['a'], int)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['z'].parents['b'], pm.CommonDeterministics.InvLogit)
 
         m = hddm.HDDMStimCoding(data, stim_col='condition', split_param='v', drift_criterion=True)
         m.sample(self.iter, burn=self.burn)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c1)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
-        self.assertEqual(m.nodes_db.ix['wfpt(c1)']['node'].parents['v'].parents['a'].__name__, 'v')
-        self.assertEqual(m.nodes_db.ix['wfpt(c1)']['node'].parents['v'].parents['b'].__name__, 'dc')
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'].parents['a'], pm.PyMCObjects.Deterministic)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'].parents['b'], pm.Normal)
-        self.assertIsInstance(m.nodes_db.ix['wfpt(c0)']['node'].parents['v'].parents['a'].parents['self'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c1)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
+        self.assertEqual(m.nodes_db.loc['wfpt(c1)']['node'].parents['v'].parents['a'].__name__, 'v')
+        self.assertEqual(m.nodes_db.loc['wfpt(c1)']['node'].parents['v'].parents['b'].__name__, 'dc')
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'], pm.PyMCObjects.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'].parents['a'], pm.PyMCObjects.Deterministic)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'].parents['b'], pm.Normal)
+        self.assertIsInstance(m.nodes_db.loc['wfpt(c0)']['node'].parents['v'].parents['a'].parents['self'], pm.Normal)
 
 
 class TestHDDMRegressor(unittest.TestCase):
@@ -200,11 +200,11 @@ class TestHDDMRegressor(unittest.TestCase):
         m = hddm.HDDMRegressor(data, 'v ~ cov', group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov_subj.0')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt.0']['node'].parents['v'].value)), 1)
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov_subj.0')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt.0']['node'].parents['v'].value)), 1)
 
     def test_link_func_on_z(self):
         params = hddm.generate.gen_rand_params()
@@ -218,12 +218,12 @@ class TestHDDMRegressor(unittest.TestCase):
 
         self.assertIn('z', m.include)
         self.assertIn('z_Intercept', m.nodes_db.knode_name)
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['z'].parents['args'][0].parents['ltheta'],
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['z'].parents['args'][0].parents['ltheta'],
                                    pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['z'].parents['args'][0].__name__, 'z_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['z'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['z'].parents['args'][1].__name__, 'z_cov_subj.0')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt.0']['node'].parents['z'].value)), 1)
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['z'].parents['args'][0].__name__, 'z_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['z'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['z'].parents['args'][1].__name__, 'z_cov_subj.0')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt.0']['node'].parents['z'].value)), 1)
         self.assertEqual(m.model_descrs[0]['link_func'](2), link_func(2))
 
     def test_no_group(self):
@@ -234,11 +234,11 @@ class TestHDDMRegressor(unittest.TestCase):
         m = hddm.HDDMRegressor(data, 'v ~ cov', group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt']['node'].parents['v'].parents['args'][1].__name__, 'v_cov')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt']['node'].parents['v'].value)), 1)
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt']['node'].parents['v'].parents['args'][1].__name__, 'v_cov')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt']['node'].parents['v'].value)), 1)
 
     def test_two_covariates(self):
         params = hddm.generate.gen_rand_params()
@@ -249,12 +249,12 @@ class TestHDDMRegressor(unittest.TestCase):
         m = hddm.HDDMRegressor(data, 'v ~ cov1 + cov2', group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov1_subj.0')
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][2].__name__, 'v_cov2_subj.0')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt.0']['node'].parents['v'].value)), 1)
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov1_subj.0')
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][2].__name__, 'v_cov2_subj.0')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt.0']['node'].parents['v'].value)), 1)
 
     def test_two_regressors(self):
         params = hddm.generate.gen_rand_params()
@@ -265,14 +265,14 @@ class TestHDDMRegressor(unittest.TestCase):
         m = hddm.HDDMRegressor(data, ['v ~ cov1', 'a ~ cov2'], group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['args'][0], pm.Gamma))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['args'][0].__name__, 'a_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov1_subj.0')
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['a'].parents['args'][1].__name__, 'a_cov2_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['args'][0], pm.Gamma))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['args'][0].__name__, 'a_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov1_subj.0')
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['a'].parents['args'][1].__name__, 'a_cov2_subj.0')
 
     def test_group_only(self):
         params = hddm.generate.gen_rand_params()
@@ -282,11 +282,11 @@ class TestHDDMRegressor(unittest.TestCase):
         m = hddm.HDDMRegressor(data, 'v ~ cov', group_only_regressors=True)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt.0']['node'].parents['v'].value)), 1)
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt.0']['node'].parents['v'].parents['args'][1].__name__, 'v_cov')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt.0']['node'].parents['v'].value)), 1)
 
     def test_group_only_depends(self):
         params = hddm.generate.gen_rand_params(cond_dict={'v': [1, 2, 3]})
@@ -295,7 +295,7 @@ class TestHDDMRegressor(unittest.TestCase):
         data['cov'] = 1.
         # Create one merged column
         data['condition2'] = 'merged'
-        data.ix[data.condition == 'c1', 'condition2'] = 'single'
+        data.loc[data.condition == 'c1', 'condition2'] = 'single'
         self.assertRaises(AssertionError, hddm.HDDMRegressor, data, 'v ~ cov', depends_on={'v_Intercept': 'condition2'}, group_only_regressors=True)
 
     def test_contrast_coding(self):
@@ -308,11 +308,11 @@ class TestHDDMRegressor(unittest.TestCase):
                                group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt(c1).0']['node'].parents['v'].parents['args'][0], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt(c1).0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
-        self.assertTrue(isinstance(m.nodes_db.ix['wfpt(c1).0']['node'].parents['v'].parents['args'][1], pm.Normal))
-        self.assertEqual(m.nodes_db.ix['wfpt(c1).0']['node'].parents['v'].parents['args'][1].__name__, 'v_C(condition)[T.c1]_subj.0')
-        self.assertEqual(len(np.unique(m.nodes_db.ix['wfpt(c1).0']['node'].parents['v'].value)), 1)
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt(c1).0']['node'].parents['v'].parents['args'][0], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt(c1).0']['node'].parents['v'].parents['args'][0].__name__, 'v_Intercept_subj.0')
+        self.assertTrue(isinstance(m.nodes_db.loc['wfpt(c1).0']['node'].parents['v'].parents['args'][1], pm.Normal))
+        self.assertEqual(m.nodes_db.loc['wfpt(c1).0']['node'].parents['v'].parents['args'][1].__name__, 'v_C(condition)[T.c1]_subj.0')
+        self.assertEqual(len(np.unique(m.nodes_db.loc['wfpt(c1).0']['node'].parents['v'].value)), 1)
 
     def test_categorical_wo_intercept(self):
         params = hddm.generate.gen_rand_params(cond_dict={'a': [1, 2, 3]})
@@ -323,12 +323,12 @@ class TestHDDMRegressor(unittest.TestCase):
                                group_only_regressors=False)
         m.sample(self.iter, burn=self.burn)
 
-        self.assertIsInstance(m.nodes_db.ix['a_C(condition)[c0]_subj.0']['node'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['a_C(condition)[c1]_subj.0']['node'], pm.Gamma)
-        self.assertIsInstance(m.nodes_db.ix['a_C(condition)[c2]_subj.0']['node'], pm.Gamma)
-        self.assertNotIsInstance(m.nodes_db.ix['a_C(condition)[T.c1]:cov_subj.0']['node'], pm.Gamma)
-        self.assertNotIsInstance(m.nodes_db.ix['a_C(condition)[T.c2]:cov_subj.0']['node'], pm.Gamma)
-        self.assertNotIsInstance(m.nodes_db.ix['a_cov_subj.0']['node'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['a_C(condition)[c0]_subj.0']['node'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['a_C(condition)[c1]_subj.0']['node'], pm.Gamma)
+        self.assertIsInstance(m.nodes_db.loc['a_C(condition)[c2]_subj.0']['node'], pm.Gamma)
+        self.assertNotIsInstance(m.nodes_db.loc['a_C(condition)[T.c1]:cov_subj.0']['node'], pm.Gamma)
+        self.assertNotIsInstance(m.nodes_db.loc['a_C(condition)[T.c2]:cov_subj.0']['node'], pm.Gamma)
+        self.assertNotIsInstance(m.nodes_db.loc['a_cov_subj.0']['node'], pm.Gamma)
 
 def test_posterior_plots_breakdown():
     params = hddm.generate.gen_rand_params()

--- a/hddm/utils.py
+++ b/hddm/utils.py
@@ -32,7 +32,7 @@ def flip_errors(data):
 
     # Flip sign for lower boundary response
     idx = data['response'] == 0
-    data.ix[idx, 'rt'] = -data.ix[idx, 'rt']
+    data.loc[idx, 'rt'] = -data.loc[idx, 'rt']
 
     return data
 


### PR DESCRIPTION
Hi, 

I already opened a PR in kabuki as well (https://github.com/hddm-devs/kabuki/pull/36). Basically, as of pandas 1.0 using `.ix.` has been removed, as `.iloc` and `.loc` are less ambiguous. I went through the hddm and kabuki code replacing `.ix` with the (hopefully) equivalent index methods. 
As far as I can test it the code seems to run and I am not introducing any new errors in the tests. But, as I am new to the hddm and kabuki, I couldn't thoroughly test the changes. A simple example, however, seems to work with pandas 1.0. 
Otherwise, setting a requirement of pandas <1.0 would of course also work. 

Best,
Simon
