### PR TITLE
Pin PyMC to <3 to avoid installation issues

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -13,5 +13,5 @@ patsy>=0.5.1
 #pytz==2012d
 #wsgiref==0.1.2
 matplotlib>=1.1.0
-pymc>=2.3.8
+pymc>=2.3.8,<3
 git+https://github.com/hddm-devs/kabuki


### PR DESCRIPTION
In https://github.com/pymc-devs/pymc/issues/6439 someone ran into installation issues because PyMC v4+ has taken over the PyPI channel.

HDDM is built with "PyMC 2" and should pin `pymc >=2.3.8,<3` to avoid any installation issues with the newer releases of PyMC3 (`pymc3>=3,<4`) or PyMC (`pymc >=4`).

cc @AlexanderFengler @twiecki 